### PR TITLE
chore: Downgrade AWS provider to align with other module

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ See the [examples/](examples/) folder and [Cloud Platform User Guide](https://us
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.31.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.25.2 |
 | <a name="requirement_opensearch"></a> [opensearch](#requirement\_opensearch) | 2.2.1 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0.0 |
@@ -113,7 +113,7 @@ See the [examples/](examples/) folder and [Cloud Platform User Guide](https://us
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.31.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0.0 |
 | <a name="provider_opensearch.app_logs"></a> [opensearch.app\_logs](#provider\_opensearch.app\_logs) | 2.2.1 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0.0 |
 

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.31.0"
+      version = ">= 4.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
We are using aws provider major version 4 for all other module but we are using aws provider major version 5 for OpenSearch Alert module.

This PR is to downgrade OpenSearch alert module aws provider to major version 4 to align with all other module.