### PR TITLE
chore: pin GitHub Actions to commit hashes for security

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -6,10 +6,10 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         ref: ${{ github.event.pull_request.head.ref }}
-    - uses: terraform-docs/gh-actions@v1.2.0
+    - uses: terraform-docs/gh-actions@e47bfa196e79fa50987ef391be236d9d97b0c786 # v1.2.0
       with:
         working-dir: .
         output-file: README.md

--- a/.github/workflows/push-terraform-module-version.yml
+++ b/.github/workflows/push-terraform-module-version.yml
@@ -7,7 +7,7 @@ jobs:
   push-terraform-module-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ministryofjustice/cloud-platform-environments/cmd/push-terraform-module-version@main
         env:
           # see https://github.com/ministryofjustice/cloud-platform-go-get-module/

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -7,8 +7,8 @@ jobs:
     name: Run Terratest Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: hashicorp/setup-terraform@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
         with:
           terraform_version: 1.2.5
           terraform_wrapper: false


### PR DESCRIPTION
### Description
This PR pins GitHub Actions to commit hashes for security.

### Related Issue
Closes https://github.com/ministryofjustice/cloud-platform-security-issues/issues/102 